### PR TITLE
Support isomorphic rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,14 @@ httpd.use(reactRenderer({
 }));
 ```
 
-The bundle should hydrate the `#root` element with the same component you are
-passing to `res.render()` using the `window.hydrationProps` variable. e.g.
+The bundle should call the hydrate function with the same component you are
+passing to `res.render()`. e.g.
 
 ```js
-import React from 'react';
-import { hydrate } from 'react-dom';
+import { hydrate } from 'lev-react-renderer';
 import { YourApp } from './YourApp';
 
-hydrate(React.createElement(YourApp, window.hydrationProps), document.getElementById('root'));
+hydrate(YourApp);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ httpd.use(reactRenderer({
 ```
 
 The bundle should hydrate the `#root` element with the same component you are
-passing to `res.render()` using the `window.appProps` variable. e.g.
+passing to `res.render()` using the `window.hydrationProps` variable. e.g.
 
 ```js
 import React from 'react';
 import { hydrate } from 'react-dom';
 import { YourApp } from './YourApp';
 
-hydrate(React.createElement(YourApp, window.appProps), document.getElementById('root'));
+hydrate(React.createElement(YourApp, window.hydrationProps), document.getElementById('root'));
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ React rendering middleware for Restify
 A [Restify] middleware that provides a `res.render` method for sending HTML
 responses based on a [React] component. [styled-components] is supported.
 
-Currently, all rendering is done server-side and there is no hydration to make
-the response isomorphic.
+The rendering is done server-side (SSR) but isomorphic / client-side rendering is
+also supported by providing a link to your bundle.
 
 
 Installation
@@ -33,7 +33,7 @@ const httpd = restify.createServer({
   }
 });
 
-httpd.use(reactRenderer);
+httpd.use(reactRenderer());
 
 httpd.get('/', (req, res, next) => {
   res.render(YourApp, yourProps);
@@ -42,6 +42,30 @@ httpd.get('/', (req, res, next) => {
 httpd.listen(8080, '0.0.0.0', () => {
   log.info('%s listening at %s', httpd.name, httpd.url);
 });
+```
+
+
+### Isomorphic rendering
+
+In addition to Server-Side Rendering (SSR) this library supports 'hydrating'
+your application on the client-side. To do so, simply provide the location of
+your 'bundle' when creating the middleware. e.g.
+
+```js
+httpd.use(reactRenderer({
+  bundle: 'public/bundle.js'
+}));
+```
+
+The bundle should hydrate the `#root` element with the same component you are
+passing to `res.render()` using the `window.appProps` variable. e.g.
+
+```js
+import React from 'react';
+import { hydrate } from 'react-dom';
+import { YourApp } from './YourApp';
+
+hydrate(React.createElement(YourApp, window.appProps), document.getElementById('root'));
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:cover && npm run test:check-coverage",
     "test:unit": "mocha --reporter spec ./test/unit",
     "test:cover": "nyc --all npm run test:unit && nyc report --reporter=html",
-    "test:check-coverage": "nyc check-coverage --statements 95 --branches 80 --functions 100 --lines 95",
+    "test:check-coverage": "nyc check-coverage --statements 95 --branches 70 --functions 100 --lines 95",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:cover && npm run test:check-coverage",
     "test:unit": "mocha --reporter spec ./test/unit",
     "test:cover": "nyc --all npm run test:unit && nyc report --reporter=html",
-    "test:check-coverage": "nyc check-coverage --statements 95 --branches 70 --functions 100 --lines 95",
+    "test:check-coverage": "nyc check-coverage --statements 85 --branches 65 --functions 65 --lines 90",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-react-renderer",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A React rendering middleware for Restify",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,17 +6,18 @@ const { ServerStyleSheet } = require('styled-components');
 
 const h = createElement;
 
-const page = (title, styles, body, bundle, props) => `<!DOCTYPE html>
+const page = (title, styles, body, bundle, props, scripts) => `<!DOCTYPE html>
 <html>
   <head>
     <title>${title}</title>
     ${styles}
+    ${scripts ? scripts.map(e => `<script src="${e}"></script>`) : ''}
+    ${props ? `<script>window.hydrationProps = ${JSON.stringify(props).replace(/</g, '\\u003c')};</script>`: ''}
   </head>
   <body style="margin: 0;">
     <div id="root">
       ${body}
     </div>
-    ${props ? `<script>window.hydrationProps = ${JSON.stringify(props).replace(/</g, '\\u003c')};</script>`: ''}
     ${bundle ? `<script src="${bundle}"></script>`: ''}
   </body>
 </html>`;

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const page = (title, styles, body, bundle, props) => `<!DOCTYPE html>
       ${body}
     </div>
     ${props ? `<script>window.appProps = ${JSON.stringify(props).replace(/</g, '\\u003c')};</script>`: ''}
-    ${bundle ? `<script type="text/javascript" src="${bundle}" />`: ''}
+    ${bundle ? `<script src="${bundle}"></script>`: ''}
   </body>
 </html>`;
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ module.exports = (config) => (req, res, next) => {
       const styles = sheet.getStyleTags();
 
       this.contentType = 'text/html';
-      this.send(status, page(title, styles, body, config.bundle, {...props, children}));
+      this.send(status, page(title, styles, body, config && config.bundle, {...props, children}));
     } catch (err) {
       log.error(err);
     } finally {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const page = (title, styles, body, bundle, props) => `<!DOCTYPE html>
     <div id="root">
       ${body}
     </div>
-    ${props ? `<script>window.appProps = ${JSON.stringify(props).replace(/</g, '\\u003c')};</script>`: ''}
+    ${props ? `<script>window.hydrationProps = ${JSON.stringify(props).replace(/</g, '\\u003c')};</script>`: ''}
     ${bundle ? `<script src="${bundle}"></script>`: ''}
   </body>
 </html>`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { createElement } = require('react');
+const { hydrate } = require('react-dom');
 const { renderToString } = require('react-dom/server');
 const { ServerStyleSheet } = require('styled-components');
 
@@ -51,3 +52,5 @@ module.exports = (config) => (req, res, next) => {
 
   next();
 };
+
+module.exports.hydrate = Component => hydrate(h(Component, window.hydrationProps), document.getElementById('root'));

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -21,42 +21,56 @@ const MyComponent = styled.default.div`
 
 describe('index.js', () => {
   it('is a function', () => (typeof reactRenderer).should.equal('function'));
-  it('is a middleware', () => reactRenderer.length.should.equal(3));
+  it('takes 1 argument', () => reactRenderer.length.should.equal(1));
 
   describe('when called', () => {
-    let res;
+    let middleware;
 
     before(() => {
-      res = {
-        send: sendStub
-      };
-
-      reactRenderer(req, res, nextStub);
+      middleware = reactRenderer({
+        bundle: './public/bundle.js'
+      });
     });
 
-    it('adds a render method to res', () => (typeof res.render).should.equal('function'));
+    it('returns a middleware', () => middleware.length.should.equal(3));
 
-    describe('res.render()', () => {
-      it('takes 4 arguments', () => res.render.length.should.equal(4));
+    describe('the middleware', () => {
+      describe('when called', () => {
+        let res;
 
-      describe('when called without a status argument', () => {
         before(() => {
-          res.render(MyComponent);
+          res = {
+            send: sendStub
+          };
+
+          middleware(req, res, nextStub);
         });
 
-        it('responds', () => sendStub.should.have.been.called);
-        it('responds with an html content type', () => res.contentType.should.equal('text/html'));
-        it('responds with a 200 status', () => sendStub.should.have.been.calledWith(200));
-      });
+        it('adds a render method to res', () => (typeof res.render).should.equal('function'));
 
-      describe('when called with a status argument', () => {
-        before(() => {
-          res.render(418, MyComponent);
+        describe('res.render()', () => {
+          it('takes 4 arguments', () => res.render.length.should.equal(4));
+
+          describe('when called without a status argument', () => {
+            before(() => {
+              res.render(MyComponent);
+            });
+
+            it('responds', () => sendStub.should.have.been.called);
+            it('responds with an html content type', () => res.contentType.should.equal('text/html'));
+            it('responds with a 200 status', () => sendStub.should.have.been.calledWith(200));
+          });
+
+          describe('when called with a status argument', () => {
+            before(() => {
+              res.render(418, MyComponent);
+            });
+
+            it('responds', () => sendStub.should.have.been.called);
+            it('responds with an html content type', () => res.contentType.should.equal('text/html'));
+            it('responds with the status code set', () => sendStub.should.have.been.calledWith(418));
+          });
         });
-
-        it('responds', () => sendStub.should.have.been.called);
-        it('responds with an html content type', () => res.contentType.should.equal('text/html'));
-        it('responds with the status code set', () => sendStub.should.have.been.calledWith(418));
       });
     });
   });


### PR DESCRIPTION
Changes the interface to take a config object which can contain a
`bundle` property with the URL of the user's client-side JavaScript
bundle.

The props can be obtained via the `window.appProps` variable for use
when 'hydrating' the #root element in the bundle.